### PR TITLE
Remove flake8 section from pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,10 +59,3 @@ disallow_untyped_defs = true
 disallow_incomplete_defs = true
 files = ["src/pdf_ocr_pipeline"]
 ignore_missing_imports = true
-
-[tool.flake8]
-max-line-length = 88
-# Ignore E203 (black compatibility) and E501 (line length) because
-# our default prompt string intentionally includes long lines and
-# black's formatting keeps them as-is.
-extend-ignore = "E203,E501"


### PR DESCRIPTION
## Summary
- drop `[tool.flake8]` from `pyproject.toml`

## Testing
- `make format`
- `make check` *(fails: No module named pytest)*
- `python -m unittest discover tests` *(fails: MissingBinaryError: pdftoppm)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed Flake8 configuration settings from the project configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->